### PR TITLE
ensure that the rabbitmq-server role is assigned in rabbitmq proposals

### DIFF
--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -63,5 +63,20 @@ class RabbitmqService < ServiceObject
     @logger.debug("Rabbitmq apply_role_pre_chef_call: leaving")
   end
 
+  def validate_proposal_after_save proposal
+    super
+
+    elements = proposal["deployment"]["rabbitmq"]["elements"]
+
+    errors = []
+
+    if not elements.has_key?("rabbitmq-server") or elements["rabbitmq-server"].length != 1
+      errors << "Need one (and only one) rabbitmq-server node."
+    end
+
+    if errors.length > 0
+      raise Chef::Exceptions::ValidationFailed.new(errors.join("\n"))
+    end
+  end
 end
 


### PR DESCRIPTION
In the future we will hopefully support HA rabbitmq, where there could be
multiple servers.

Currently there's only one possible validation error, but we follow the
pattern used by other barclamps for building an errors array and joining it,
to allow easy addition of other errors in the future.
