### PR TITLE
Use correct path for rabbitmq-plugins on SUSE

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -98,11 +98,10 @@ service "rabbitmq-server" do
   action [:enable, :start]
 end
 
+rabbitmq_plugins = "#{Config::CONFIG["libdir"]}/rabbitmq/bin/rabbitmq-plugins"
+
 bash "Enable rabbit management" do
-  code <<-'EOH'
-/usr/lib/rabbitmq/bin/rabbitmq-plugins enable rabbitmq_management
-exit 0
-EOH
-  not_if "su - rabbitmq -s /bin/bash -c \"/usr/lib/rabbitmq/bin/rabbitmq-plugins list -E\" | grep -q rabbitmq_management"
+  code "#{rabbitmq_plugins} enable rabbitmq_management || :"
+  not_if "su - rabbitmq -s /bin/bash -c \"#{rabbitmq_plugins} list -E\" | grep -q rabbitmq_management"
   notifies :restart, "service[rabbitmq-server]", :immediately
 end unless node.platform == "suse"


### PR DESCRIPTION
This will not have any direct benefit for now (since we don't have
the rabbitmq_management plugin yet), but it's still nice to already do
that.
