### PR TITLE
Fix CHEF-3694 caused by bad resource naming

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -28,14 +28,16 @@ rabbitmq_vhost node[:rabbitmq][:vhost] do
 end
 
 # create user for the queue
-rabbitmq_user node[:rabbitmq][:user] do
+rabbitmq_user "adding user #{node[:rabbitmq][:user]}" do
+  user node[:rabbitmq][:user]
   password node[:rabbitmq][:password]
   action :add
 end
 
 # grant the mapper user the ability to do anything with the vhost
 # the three regex's map to config, write, read permissions respectively
-rabbitmq_user node[:rabbitmq][:user] do
+rabbitmq_user "setting permissions for #{node[:rabbitmq][:user]}" do
+  user node[:rabbitmq][:user]
   vhost node[:rabbitmq][:vhost]
   permissions "\".*\" \".*\" \".*\""
   action :set_permissions


### PR DESCRIPTION
Two resources have the same name, which leads to:

WARN: Cloning resource attributes for rabbitmq_user[nova] from prior resource (CHEF-3694)
WARN: Previous rabbitmq_user[nova]: /var/chef/cache/cookbooks/rabbitmq/recipes/rabbit.rb:31:in `from_file'
WARN: Current  rabbitmq_user[nova]: /var/chef/cache/cookbooks/rabbitmq/recipes/rabbit.rb:38:in`from_file'
