### PR TITLE
Enable and start the RabbitMQ service

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -18,11 +18,6 @@
 # limitations under the License.
 #
 
-service "rabbitmq-server" do
-  supports :restart => true, :start => true, :stop => true
-  action :nothing
-end
-
 directory "/etc/rabbitmq/" do
   owner "root"
   group "root"
@@ -49,7 +44,13 @@ end
 package "rabbitmq-server"
 package "rabbitmq-server-plugins" if node.platform == "suse"
 
+service "rabbitmq-server" do
+  supports :restart => true, :start => true, :stop => true
+  action [ :enable, :start ]
+end
+
 rabbitmq_plugins = "#{RbConfig::CONFIG["libdir"]}/rabbitmq/bin/rabbitmq-plugins"
+rabbitmq_plugins = "/usr/sbin/rabbitmq-plugins" if node.platform == "suse"
 
 bash "enabling rabbit management" do
   code "#{rabbitmq_plugins} enable rabbitmq_management > /dev/null"


### PR DESCRIPTION
Fixes a regression introduced by:
https://github.com/crowbar/barclamp-rabbitmq/pull/14

On SUSE, other than on Ubuntu the rabbitmq service is not automatically enabled
and started after the package installation. So this needs to be done by the
cookbook. There shouldn't be the need to special case this for SUSE as the
:enable and :start action shouldn't do anything if the service is already
enabled and running (as on Ubuntu).

Additionally this sets the correct path to the rabbitmq-plugins binary on SUSE
platforms.
