### PR TITLE
rabbitmq-plugins needs HOME set to work correctly

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -53,7 +53,8 @@ rabbitmq_plugins = "#{RbConfig::CONFIG["libdir"]}/rabbitmq/bin/rabbitmq-plugins"
 rabbitmq_plugins = "/usr/sbin/rabbitmq-plugins" if node.platform == "suse"
 
 bash "enabling rabbit management" do
+  environment "HOME" => "/root/"
   code "#{rabbitmq_plugins} enable rabbitmq_management > /dev/null"
-  not_if "#{rabbitmq_plugins} list -E | grep rabbitmq_management -q"
+  not_if "#{rabbitmq_plugins} list -E | grep rabbitmq_management -q", :environment => {"HOME" => "/root/"}
   notifies :restart, "service[rabbitmq-server]"
 end


### PR DESCRIPTION
Otherwise it will fail with "erlexec: HOME must be set"
