### PR TITLE
propose rabbitmq for controller node

### DIFF
--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -38,8 +38,8 @@ class RabbitmqService < ServiceObject
     nodes = NodeObject.all
     nodes.delete_if { |n| n.nil? }
     nodes.delete_if { |n| n.admin? } if nodes.size > 1
+    controller = nodes.find { |n| n if n.intended_role == "controller" } || nodes.first
     base["deployment"]["rabbitmq"]["elements"] = {
-      controller = nodes.find { |n| n if n.intended_role == "controller" } || nodes.first
       "rabbitmq-server" => [ controller.name ]
     }
 


### PR DESCRIPTION
Use the intended role set for the nodes to propose rabbitmq deployment.
(Requires changes in barclamp-crowbar: https://github.com/crowbar/barclamp-crowbar/pull/796)
