### PR TITLE
[WIP] [roxy] allow VIP and filesystem to start in parallel

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/ha.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha.rb
@@ -251,6 +251,7 @@ if node[:rabbitmq][:ha][:storage][:mode] == "drbd"
     action :create
     # This is our last constraint, so we can finally start service_name
     notifies :run, "execute[Cleanup #{service_name} after constraints]", :immediately
+    notifies :start, "pacemaker_primitive[#{vip_primitive}]", :immediately
     notifies :start, "pacemaker_primitive[#{service_name}]", :immediately
   end
 


### PR DESCRIPTION
**DO NOT MERGE YET** - untested.

Any unnecessary ordering between the VIP and filesystem resources can cause problems during the chef-client run.

This requires and is required by https://github.com/crowbar/barclamp-pacemaker/pull/92, which also requires https://github.com/crowbar/barclamp-database/pull/77.

This is tracked by https://trello.com/c/5SWxhpxf
