### PR TITLE
change DRBD disk size to a float

### DIFF
--- a/chef/data_bags/crowbar/bc-template-rabbitmq.json
+++ b/chef/data_bags/crowbar/bc-template-rabbitmq.json
@@ -11,7 +11,7 @@
         "storage": {
           "mode": "shared",
           "drbd": {
-            "size": 50
+            "size": 50.0
           },
           "shared": {
             "device": "",

--- a/chef/data_bags/crowbar/bc-template-rabbitmq.schema
+++ b/chef/data_bags/crowbar/bc-template-rabbitmq.schema
@@ -29,7 +29,7 @@
                       "type": "map",
                       "required": true,
                       "mapping" : {
-                        "size": { "type": "int", "required": true }
+                        "size": { "type": "float", "required": true }
                       }
                     },
                     "shared": {

--- a/crowbar_framework/app/views/barclamp/rabbitmq/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/rabbitmq/_edit_attributes.html.haml
@@ -16,7 +16,7 @@
       #drbd_storage_container
         .alert.alert-info
           = t('.ha.storage.drbd_info')
-        = integer_field %w(ha storage drbd size)
+        = float_field %w(ha storage drbd size)
 
       #shared_storage_container
         = string_field %w(ha storage shared device)


### PR DESCRIPTION
LVM reserves some space for meta-data, so the actual space available for the DRBD LV will be smaller than the raw device size.  Unfortunately this doesn't help the UX much but at least it avoids forcing the operator to wasting an entire GB of disk.

See also https://github.com/crowbar/barclamp-database/pull/78