### PR TITLE
Fix drag n drop for deployment

### DIFF
--- a/crowbar_framework/app/views/barclamp/rabbitmq/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/rabbitmq/_edit_attributes.html.haml
@@ -7,7 +7,7 @@
     = integer_field :port
     = string_field :user
 
-    %fieldset#ha-setup{ "data-show-for-clusters-only" => "true", "data-elements-path" => "database-server" }
+    %fieldset#ha-setup{ "data-show-for-clusters-only" => "true", "data-elements-path" => "rabbitmq-server" }
       %legend
         = t('.ha_header')
 


### PR DESCRIPTION
For the HA parts we added the `data-elements-path` attribute, and
this should be named `rabbitmq-server` instead of `database-server`.
