### PR TITLE
Re-add the address attribute

### DIFF
--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -25,6 +25,9 @@ default[:rabbitmq][:user] = "nova"
 default[:rabbitmq][:vhost] = "/nova"
 
 default[:rabbitmq][:nodename]  = node[:hostname]
+# This is the address for internal usage
+default[:rabbitmq][:address] = nil
+# These are all the addresses, possibly including public one
 default[:rabbitmq][:addresses] = []
 default[:rabbitmq][:port]  = 5672
 default[:rabbitmq][:mochiweb_port] = 55672

--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -20,8 +20,9 @@
 
 ha_enabled = node[:rabbitmq][:ha][:enabled]
 
-node[:rabbitmq][:mochiweb_address] = CrowbarRabbitmqHelper.get_listen_address(node)
-node[:rabbitmq][:addresses] = [ CrowbarRabbitmqHelper.get_listen_address(node) ]
+node[:rabbitmq][:address] = CrowbarRabbitmqHelper.get_listen_address(node)
+node[:rabbitmq][:mochiweb_address] = node[:rabbitmq][:address]
+node[:rabbitmq][:addresses] = [ node[:rabbitmq][:address] ]
 node[:rabbitmq][:addresses] << CrowbarRabbitmqHelper.get_public_listen_address(node) if node[:rabbitmq][:listen_public]
 
 if ha_enabled


### PR DESCRIPTION
It's being used by all barclamps to get the admin address on which
rabbitmq is listening.
