### PR TITLE
Adapt configuration for rabbitmq >= 3.0

### DIFF
--- a/chef/cookbooks/rabbitmq/attributes/default.rb
+++ b/chef/cookbooks/rabbitmq/attributes/default.rb
@@ -30,8 +30,8 @@ default[:rabbitmq][:address] = nil
 # These are all the addresses, possibly including public one
 default[:rabbitmq][:addresses] = []
 default[:rabbitmq][:port]  = 5672
-default[:rabbitmq][:mochiweb_port] = 55672
-default[:rabbitmq][:mochiweb_address] = nil
+default[:rabbitmq][:management_port] = 15672
+default[:rabbitmq][:management_address] = nil
 default[:rabbitmq][:configfile] = nil
 default[:rabbitmq][:logdir] = nil
 default[:rabbitmq][:mnesiadir] = nil

--- a/chef/cookbooks/rabbitmq/recipes/rabbit.rb
+++ b/chef/cookbooks/rabbitmq/recipes/rabbit.rb
@@ -21,7 +21,7 @@
 ha_enabled = node[:rabbitmq][:ha][:enabled]
 
 node[:rabbitmq][:address] = CrowbarRabbitmqHelper.get_listen_address(node)
-node[:rabbitmq][:mochiweb_address] = node[:rabbitmq][:address]
+node[:rabbitmq][:management_address] = node[:rabbitmq][:address]
 node[:rabbitmq][:addresses] = [ node[:rabbitmq][:address] ]
 node[:rabbitmq][:addresses] << CrowbarRabbitmqHelper.get_public_listen_address(node) if node[:rabbitmq][:listen_public]
 
@@ -59,8 +59,8 @@ end
 rabbitmq_user "adding user #{node[:rabbitmq][:user]}" do
   user node[:rabbitmq][:user]
   password node[:rabbitmq][:password]
-  address node[:rabbitmq][:mochiweb_address]
-  port node[:rabbitmq][:mochiweb_port]
+  address node[:rabbitmq][:management_address]
+  port node[:rabbitmq][:management_port]
   action :add
   only_if only_if_command if ha_enabled
 end
@@ -90,8 +90,8 @@ if node[:rabbitmq][:trove][:enabled]
   rabbitmq_user "adding user #{node[:rabbitmq][:trove][:user]}" do
     user node[:rabbitmq][:trove][:user]
     password node[:rabbitmq][:trove][:password]
-    address node[:rabbitmq][:mochiweb_address]
-    port node[:rabbitmq][:mochiweb_port]
+    address node[:rabbitmq][:management_address]
+    port node[:rabbitmq][:management_port]
     action :add
     only_if only_if_command if ha_enabled
   end
@@ -108,8 +108,8 @@ if node[:rabbitmq][:trove][:enabled]
 else
   rabbitmq_user "deleting user #{node[:rabbitmq][:trove][:user]}" do
     user node[:rabbitmq][:trove][:user]
-    address node[:rabbitmq][:mochiweb_address]
-    port node[:rabbitmq][:mochiweb_port]
+    address node[:rabbitmq][:management_address]
+    port node[:rabbitmq][:management_port]
     action :delete
     only_if only_if_command if ha_enabled
   end

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -7,9 +7,9 @@
    {disk_free_limit, 50000000}
   ]
  },
- {rabbitmq_mochiweb,
+ {rabbitmq_management,
   [
-   {listeners, [{mgmt, [{ip, "<%= node[:rabbitmq][:mochiweb_address] %>"}, {port, <%= node[:rabbitmq][:mochiweb_port] %>}]}]}
+   {listener, [{ip, "<%= node[:rabbitmq][:management_address] %>"}, {port, <%= node[:rabbitmq][:management_port] %>}]}
   ]
  }
 ].


### PR DESCRIPTION
Starting with Rabbitmq-Server 3.0, the mochiweb interface
was renamed to management interface and moved to port 15672.
See http://www.rabbitmq.com/management.html for details.
