### PR TITLE
Allow deploying rabbitmq on SLE12 nodes

### DIFF
--- a/crowbar_framework/app/models/rabbitmq_service.rb
+++ b/crowbar_framework/app/models/rabbitmq_service.rb
@@ -34,7 +34,6 @@ class RabbitmqService < PacemakerServiceObject
           "unique" => false,
           "count" => 1,
           "exclude_platform" => {
-            "suse" => "12.0",
             "windows" => "/.*/"
           },
           "cluster" => true


### PR DESCRIPTION
Also: Extend epmd.socket unit file to listen on 0.0.0.0

Right now, epmd.socket makes systemd only listen on 127.0.0.1 which
makes rabbitmq-server fail to start. So we extend the socket unit file
to listen on 0.0.0.0.

Note that for some reason, it fails when we only listen on the admin IP
address.

See also discussion at
https://bugzilla.redhat.com/show_bug.cgi?id=1104843