### PR TITLE
fix Rabbit HA for non-DRBD case (bnc#935159)

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/ha.rb
+++ b/chef/cookbooks/rabbitmq/recipes/ha.rb
@@ -288,9 +288,9 @@ dependencies = [ fs_primitive, admin_vip_primitive ]
 if node[:rabbitmq][:listen_public]
   dependencies << public_vip_primitive
 end
-primitives = "( #{dependencies.join ' '} ) " + service_name
 
 if node[:rabbitmq][:ha][:storage][:mode] == "drbd"
+  primitives = "( #{dependencies.join ' '} ) " + service_name
 
   pacemaker_colocation "col-#{service_name}" do
     score "inf"
@@ -319,6 +319,8 @@ if node[:rabbitmq][:ha][:storage][:mode] == "drbd"
   end
 
 else
+  # Pacemaker groups do not support parallel startup ordering :-(
+  primitives = dependencies + [service_name]
 
   pacemaker_group group_name do
     # Membership order *is* significant; VIPs should come first so


### PR DESCRIPTION
Backport of #77, not yet tested!

Unfortunately #74 / #75 (accidentally duplicated backports of #73) broke the non-DRBD case, since the Pacemaker group resource doesn't support parentheses.

https://github.com/crowbar/barclamp-rabbitmq/pull/73/files
https://bugzilla.suse.com/show_bug.cgi?id=935159

(cherry picked from commit a127eb7fb96637cd28969836b04eaca74d5af294)
